### PR TITLE
Added Types and made a little update on visualization

### DIFF
--- a/particlelife/particles.py
+++ b/particlelife/particles.py
@@ -6,12 +6,27 @@ class Particles:
         self.n_points = n_points
         self.x = np.random.normal(loc=0.0, scale=10.0, size=n_points)
         self.y = np.random.normal(loc=0.0, scale=10.0, size=n_points)
+        
+        
+
         self.vx = np.zeros(n_points)
         self.vy = np.zeros(n_points)
+
+       
+        self.types = np.repeat(np.arange(4), n_points // 4)
+        np.random.shuffle(self.types)
+        
+        self.colors = np.array([
+            [0.0, 0.0, 1.0],  # Typ0:blue
+            [1.0, 0.0, 0.0],  # Typ1:red
+            [0.0, 1.0, 0.0],  # Typ2:green
+            [1.0, 1.0, 0.0],  # Typ3:yellow
+        ])
 
     def diffuse(self, n_step=0.1):
         self.x += np.random.normal(scale=n_step, size=self.x.shape)
         self.y += np.random.normal(scale=n_step, size=self.y.shape)
+
         self.x += self.vx
         self.y += self.vy
         return self.x, self.y

--- a/particlelife/visualization.py
+++ b/particlelife/visualization.py
@@ -20,6 +20,9 @@ class Visualization(QMainWindow):
         x = self.particles.x
         y = self.particles.y
 
+        types = self.particles.types
+        face_colors = self.particles.colors[types]
+
         # DEBUG
         print("x shape:", x.shape)
         print("y shape:", y.shape)
@@ -32,7 +35,7 @@ class Visualization(QMainWindow):
 
         self.scatter.set_data(
             positions,
-            face_color="cyan",
+            face_color=face_colors,
             size=5
         )
 
@@ -45,10 +48,11 @@ class Visualization(QMainWindow):
         x, y = self.particles.diffuse(0.2)
 
         positions = np.column_stack((x, y))  # wieder (N, 2)
-
+        types = self.particles.types
+        face_colors = self.particles.colors[types]
         # Visual aktualisieren
         self.scatter.set_data(
             positions,
-            face_color="cyan",
+            face_color=face_colors,
             size=5
         )


### PR DESCRIPTION
We added four different particle types (0-3) and made sure they are spread evenly across all particles.
Each type now has its own color, which is defined directly in the Particles class.
The visualization was updated so that every particle is drawn with the color that matches its type, instead of using only one color.
This makes the particles easier to tell apart and prepares the project for future interaction rules between the types.